### PR TITLE
remove buttons outline

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -8,7 +8,7 @@ const AppWrapper = styled.div`
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  width: 700px;
+  width: 500px;
   margin: 0 auto;
 `
 

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -2,24 +2,24 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-const CalcButton = styled.input`
-  width: ${props => (props.wide ? '50%' : '25%')};
-  height: 100%;
-  font-size: 3rem;
-  text-align: center;
-  border: solid #eee 5px;
-  color: #000;
-  background-color: ${props => props.color || '#ddd'};
-  cursor: pointer;
-
-  :hover {
-    background-color: ${props => (props.color ? '#ff9926' : '#bbb')};
-  }
-`
-
 const Button = ({ buttonName, color, wide, clickHandler }) => {
   let input
 
+  const CalcButton = styled.input`
+    width: ${props => (props.wide ? '50%' : '25%')};
+    height: 100%;
+    font-size: 3rem;
+    text-align: center;
+    border: solid #eee 5px;
+    color: #000;
+    background-color: ${props => props.color || '#ddd'};
+    cursor: pointer;
+    outline: none;
+
+    :hover {
+      background-color: ${props => (props.color ? '#ff9926' : '#bbb')};
+    }
+  `
   const handleClick = buttonName => {
     return clickHandler(input.value)
   }

--- a/src/components/Display.js
+++ b/src/components/Display.js
@@ -5,11 +5,11 @@ import styled from 'styled-components'
 const Input = styled.input`
   display: flex;
   height: 100px;
-  color: #fff;
-  font-weight: bold;
   padding: 10px;
+  font-weight: bold;
   text-align: right;
   background-color: #aaa;
+  color: #fff;
   font-size: 4rem;
   border: none;
 `


### PR DESCRIPTION
reduce width of calculator to `500px`
add `outline: none`; to CalcButton style

fixes #1